### PR TITLE
fix(aurelia2-table): restore sort runtime compatibility

### DIFF
--- a/packages/aurelia2-table/package.json
+++ b/packages/aurelia2-table/package.json
@@ -4,6 +4,10 @@
   "description": "A port of the Aurelia Table plugin to v2",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
   "repository": "https://github.com/Vheissu/aurelia2-plugins",
   "author": "Dwayne Charrington <dwaynecharrington@gmail.com",
   "license": "MIT",

--- a/packages/aurelia2-table/src/aurelia-table-attribute.ts
+++ b/packages/aurelia2-table/src/aurelia-table-attribute.ts
@@ -35,6 +35,10 @@ export class AureliaTableCustomAttribute {
         this.applyPlugins();
     }
 
+    bound() {
+        this.applyPlugins();
+    }
+
     dataChanged() {
         this.applyPlugins();
     }

--- a/packages/aurelia2-table/src/aurelia-table-select.ts
+++ b/packages/aurelia2-table/src/aurelia-table-select.ts
@@ -1,8 +1,7 @@
-import { bindable, BindingMode, customAttribute, CustomAttribute, INode, inject, optional, watch } from 'aurelia';
+import { bindable, BindingMode, customAttribute, CustomAttribute, watch } from 'aurelia';
 import { AureliaTableCustomAttribute } from './aurelia-table-attribute.js';
 
 @customAttribute('aut-select')
-@inject(optional(AureliaTableCustomAttribute), INode)
 export class AutSelectCustomAttribute {
   @bindable({mode: BindingMode.twoWay}) row;
   @bindable mode = 'single';
@@ -10,20 +9,42 @@ export class AutSelectCustomAttribute {
   @bindable custom = false;
 
   private rowSelectedListener;
+  private element!: HTMLElement;
+  private controller: any;
+  private auTable: AureliaTableCustomAttribute | null = null;
 
-  constructor(
-    private auTable: AureliaTableCustomAttribute | null,
-    private readonly element: HTMLElement
-  ) {
+  constructor() {
     this.rowSelectedListener = event => {
       this.handleRowSelected(event);
     };
   }
 
-  attached() {
-    if (!this.auTable) {
-      this.auTable = CustomAttribute.closest(this.element, AureliaTableCustomAttribute)?.viewModel ?? null;
+  created(controller) {
+    this.controller = controller;
+    this.element = controller.host as HTMLElement;
+  }
+
+  resolveTable() {
+    let currentController = this.controller?.parent;
+    while (currentController != null) {
+      if (currentController.viewModel instanceof AureliaTableCustomAttribute) {
+        this.auTable = currentController.viewModel;
+        return;
+      }
+      currentController = currentController.parent;
     }
+
+    const tableElement = this.element?.closest('table');
+    const tableController = tableElement
+      ? CustomAttribute.for(tableElement, 'aurelia-table')
+      : null;
+
+    this.auTable = tableController?.viewModel as AureliaTableCustomAttribute | null
+      ?? CustomAttribute.closest(this.element, AureliaTableCustomAttribute)?.viewModel as AureliaTableCustomAttribute | null;
+  }
+
+  attached() {
+    this.resolveTable();
 
     if (!this.custom && this.element) {
       this.element.style.cursor = 'pointer';
@@ -37,6 +58,9 @@ export class AutSelectCustomAttribute {
     if (!this.custom) {
       this.element?.removeEventListener('click', this.rowSelectedListener);
     }
+
+    this.auTable = null;
+    this.controller = null;
   }
 
   setClass() {

--- a/packages/aurelia2-table/src/aurelia-table-sort.ts
+++ b/packages/aurelia2-table/src/aurelia-table-sort.ts
@@ -1,9 +1,8 @@
-import { bindable, CustomAttribute, customAttribute, INode, inject, optional } from 'aurelia';
+import { bindable, CustomAttribute, customAttribute } from 'aurelia';
 
 import { AureliaTableCustomAttribute } from './aurelia-table-attribute.js';
 
 @customAttribute('aut-sort')
-@inject(optional(AureliaTableCustomAttribute), INode)
 export class AutSortCustomAttribute {
     @bindable key;
     @bindable custom;
@@ -11,16 +10,17 @@ export class AutSortCustomAttribute {
 
     private rowSelectedListener;
     private sortChangedListener;
+    private element!: HTMLElement;
+    private controller: any;
+    private auTable: AureliaTableCustomAttribute | null = null;
 
     order = 0;
     orderClasses = ['aut-desc', 'aut-sortable', 'aut-asc'];
 
     ignoreEvent = false;
+    isInitialized = false;
 
-    constructor(
-        private auTable: AureliaTableCustomAttribute | null,
-        private readonly element: HTMLElement
-    ) {
+    constructor() {
         this.rowSelectedListener = () => {
             this.handleHeaderClicked();
         };
@@ -28,6 +28,38 @@ export class AutSortCustomAttribute {
         this.sortChangedListener = () => {
             this.handleSortChanged();
         };
+    }
+
+    created(controller) {
+        this.controller = controller;
+        this.element = controller.host as HTMLElement;
+    }
+
+    keyChanged() {
+        this.initializeSorting();
+    }
+
+    customChanged() {
+        this.initializeSorting();
+    }
+
+    resolveTable() {
+        let currentController = this.controller?.parent;
+        while (currentController != null) {
+            if (currentController.viewModel instanceof AureliaTableCustomAttribute) {
+                this.auTable = currentController.viewModel;
+                return;
+            }
+            currentController = currentController.parent;
+        }
+
+        const tableElement = this.element?.closest('table');
+        const tableController = tableElement
+            ? CustomAttribute.for(tableElement, 'aurelia-table')
+            : null;
+
+        this.auTable = tableController?.viewModel as AureliaTableCustomAttribute | null
+            ?? CustomAttribute.closest(this.element, AureliaTableCustomAttribute)?.viewModel as AureliaTableCustomAttribute | null;
     }
 
     handleSortChanged() {
@@ -40,27 +72,41 @@ export class AutSortCustomAttribute {
     }
 
     attached() {
-        if (!this.auTable) {
-            this.auTable = CustomAttribute.closest(this.element, AureliaTableCustomAttribute)?.viewModel ?? null;
-        }
-
-        if ((this.key || this.custom) && this.element && this.auTable) {
-            this.element.style.cursor = 'pointer';
-            this.element.classList.add('aut-sort');
-
-            this.element.addEventListener('click', this.rowSelectedListener);
-            this.auTable.addSortChangedListener(this.sortChangedListener);
-
-            this.handleDefault();
-            this.setClass();
-        }
+        this.initializeSorting();
     }
 
     detached() {
-        if (this.key || this.custom) {
+        if (this.isInitialized) {
             this.element?.removeEventListener('click', this.rowSelectedListener);
             this.auTable?.removeSortChangedListener(this.sortChangedListener);
         }
+
+        this.auTable = null;
+        this.controller = null;
+        this.isInitialized = false;
+    }
+
+    initializeSorting() {
+        if (this.isInitialized || !(this.key || this.custom) || !this.element) {
+            return;
+        }
+
+        this.resolveTable();
+
+        if (!this.auTable) {
+            return;
+        }
+
+        this.element.style.cursor = 'pointer';
+        this.element.classList.add('aut-sort');
+
+        this.element.addEventListener('click', this.rowSelectedListener);
+        this.auTable.addSortChangedListener(this.sortChangedListener);
+
+        this.isInitialized = true;
+
+        this.handleDefault();
+        this.setClass();
     }
 
     handleDefault() {
@@ -70,7 +116,7 @@ export class AutSortCustomAttribute {
         }
     }
 
-  doSort() {
+    doSort() {
         if (!this.auTable) {
             return;
         }

--- a/packages/aurelia2-table/test/aurelia-table-sort.spec.ts
+++ b/packages/aurelia2-table/test/aurelia-table-sort.spec.ts
@@ -1,0 +1,58 @@
+﻿import { describe, expect, test } from '@jest/globals';
+
+import { AureliaTableCustomAttribute } from '../src/aurelia-table-attribute';
+import { AutSortCustomAttribute } from '../src/aurelia-table-sort';
+
+describe('aurelia2-table sort', () => {
+  test('aut-sort initializes after key arrives and sorts on click', () => {
+    const tableViewModel = new AureliaTableCustomAttribute();
+    tableViewModel.isAttached = true;
+    tableViewModel.data = [
+      { name: 'Charlie' },
+      { name: 'Alice' },
+      { name: 'Bob' }
+    ] as any;
+
+    const header = document.createElement('th');
+    const sortViewModel = new AutSortCustomAttribute();
+
+    sortViewModel.created({
+      host: header,
+      parent: {
+        viewModel: tableViewModel,
+        parent: null
+      }
+    } as any);
+
+    sortViewModel.attached();
+
+    expect(tableViewModel.sortKey).toBeUndefined();
+    expect(header.classList.contains('aut-sort')).toBe(false);
+
+    sortViewModel.key = 'name';
+    sortViewModel.keyChanged();
+
+    expect(header.classList.contains('aut-sort')).toBe(true);
+
+    header.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(tableViewModel.sortKey).toBe('name');
+    expect(tableViewModel.sortOrder).toBe(1);
+    expect(tableViewModel.displayData.map((row: any) => row.name)).toEqual(['Alice', 'Bob', 'Charlie']);
+    expect(header.classList.contains('aut-asc')).toBe(true);
+  });
+
+  test('sortChanged sorts local data ascending', () => {
+    const tableViewModel = new AureliaTableCustomAttribute();
+    tableViewModel.isAttached = true;
+    tableViewModel.data = [
+      { name: 'Charlie' },
+      { name: 'Alice' },
+      { name: 'Bob' }
+    ] as any;
+
+    tableViewModel.sortChanged('name', undefined, 1);
+
+    expect(tableViewModel.displayData.map((row: any) => row.name)).toEqual(['Alice', 'Bob', 'Charlie']);
+  });
+});


### PR DESCRIPTION
I ran into some issues with the latest version where sort was no longer working because this.auTable was undefined in the call to attached in aurelia-table-sort.ts. A new unit test confirmed the issue and a related issue when the th contained an if.bind. I also had to move the package to rc1 to be compatible with my deployment.

## Summary
- fix `aut-sort` initialization when the parent table attribute is resolved after construction
- make `aut-select` use the same runtime-safe table resolution path
- reapply table plugins from `bound()` so initial binding state is handled consistently
- add a regression test covering delayed `aut-sort` initialization and sorting
- update package metadata and Jest mapping for the workspace package

## Verification
- `npm run build --workspace packages/aurelia2-table`
- `npm test --workspace packages/aurelia2-table`
- `npm pack --workspace packages/aurelia2-table --dry-run`