### PR TITLE
feat(aurelia2-turnstile): add Cloudflare Turnstile plugin

### DIFF
--- a/packages/aurelia2-turnstile/README.md
+++ b/packages/aurelia2-turnstile/README.md
@@ -1,0 +1,385 @@
+﻿# aurelia2-turnstile
+
+A Cloudflare Turnstile integration for Aurelia 2 applications. Provides a simple custom element to render the [Cloudflare Turnstile](https://developers.cloudflare.com/turnstile/) CAPTCHA widget.
+
+## Installation
+
+```bash
+npm install aurelia2-turnstile
+```
+
+If you are testing a local build before the package is published, you can install from the generated tarball instead:
+
+```bash
+npm install ./path/to/aurelia2-turnstile-1.0.0.tgz
+```
+
+Replace the filename with the version you packed locally.
+
+## Register the Plugin
+
+`TurnstileConfiguration.configure({...})` is the recommended entry point when you already know your options as a plain object. Use `TurnstileConfiguration.customize(...)` when you want callback-style setup.
+
+Inside of `main.ts`/`main.js`, register the plugin with your sitekey:
+
+```ts
+import Aurelia from 'aurelia';
+import { TurnstileConfiguration } from 'aurelia2-turnstile';
+import { MyApp } from './my-app';
+
+Aurelia.register(
+  TurnstileConfiguration.configure({
+    sitekey: 'YOUR_CLOUDFLARE_TURNSTILE_SITE_KEY',
+  })
+).app(MyApp).start();
+```
+
+Many Aurelia 2 apps create the Aurelia instance first and register dependencies separately. That pattern works as well:
+
+```ts
+import Aurelia from 'aurelia';
+import { TurnstileConfiguration } from 'aurelia2-turnstile';
+import { MyApp } from './my-app';
+
+const au = new Aurelia();
+
+au.register(
+  TurnstileConfiguration.configure({
+    sitekey: 'YOUR_CLOUDFLARE_TURNSTILE_SITE_KEY',
+  })
+);
+
+await au.app(MyApp).start();
+```
+
+### Configuration Options
+
+| Option      | Type                              | Default                                                                 | Description                          |
+|-------------|-----------------------------------|-------------------------------------------------------------------------|--------------------------------------|
+| `sitekey`   | `string`                          | `''`                                                                    | Your Cloudflare Turnstile site key   |
+| `theme`     | `'light'` \| `'dark'` \| `'auto'` | `'auto'`                                                                | Widget theme                         |
+| `scriptUrl` | `string`                          | `'https://challenges.cloudflare.com/turnstile/v0/api.js'` | URL for the Turnstile script         |
+
+### `configure()` vs `customize()`
+
+- Use `configure({...})` when you already know your plugin options up front.
+- Use `customize(config => ...)` when you prefer callback-style configuration or want to set options in multiple statements.
+
+### Callback-style Configuration
+
+```ts
+import { TurnstileConfiguration } from 'aurelia2-turnstile';
+
+Aurelia.register(
+  TurnstileConfiguration.customize((config) => {
+    config.options({
+      sitekey: 'YOUR_SITE_KEY',
+      theme: 'auto',
+    });
+  })
+);
+```
+
+## Content Security Policy
+
+If your app uses a `Content-Security-Policy` header, Turnstile will not load unless Cloudflare's script and iframe origins are allowed.
+
+At minimum, allow:
+
+```text
+script-src https://challenges.cloudflare.com
+frame-src https://challenges.cloudflare.com
+```
+
+If you use Turnstile pre-clearance mode, Cloudflare also recommends keeping `connect-src 'self'` available. See Cloudflare's CSP documentation for the full guidance, including nonce-based setups.
+
+## Usage
+
+When a user completes the Turnstile challenge, the plugin dispatches a `turnstile-verified` custom DOM event with the token in `$event.detail.token`. You can also use the `callback` bindable directly.
+
+### Using the Event (Recommended)
+
+The `turnstile-verified` event is the recommended approach because Aurelia's `.trigger` binding handles method context automatically — no need for `.bind(this)` in your constructor.
+
+**Template (`contact-page.html`):**
+
+```html
+<form submit.trigger="sendContactInfo()">
+  <label>Name</label>
+  <input type="text" value.bind="contactViewModel.name & validate" />
+
+  <label>Email</label>
+  <input type="email" value.bind="contactViewModel.email & validate" />
+
+  <label>Subject</label>
+  <input type="text" value.bind="contactViewModel.subject & validate" />
+
+  <label>Message</label>
+  <textarea value.bind="contactViewModel.message & validate"></textarea>
+
+  <turnstile turnstile-verified.trigger="onTurnstileSuccess($event)"></turnstile>
+
+  <button type="submit">Send</button>
+</form>
+```
+
+**View Model (`contact-page.ts`):**
+
+```ts
+import { inject, newInstanceForScope } from '@aurelia/kernel';
+import { IRouter } from '@aurelia/router';
+import { IValidationRules } from '@aurelia/validation';
+import { IValidationController } from '@aurelia/validation-html';
+import { HomeService } from './home-service.js';
+
+interface IContactViewModel {
+  name: string;
+  email: string;
+  phone: string;
+  subject: string;
+  message: string;
+  turnstileToken: string;
+}
+
+@inject(HomeService, IRouter, newInstanceForScope(IValidationController), IValidationRules)
+export class ContactPage {
+  private contactViewModel: IContactViewModel = {
+    name: '', email: '', phone: '', subject: '', message: '', turnstileToken: ''
+  };
+
+  constructor(
+    private readonly homeService: HomeService,
+    private readonly router: IRouter,
+    private validationController: IValidationController,
+    private validationRules: IValidationRules
+  ) { }
+
+  async binding() {
+    this.validationRules
+      .on(this.contactViewModel)
+      .ensure('name').required().withMessage('Name is required')
+      .ensure('email').required().email().withMessage('A valid Email is required')
+      .ensure('subject').required().withMessage('Subject is required')
+      .ensure('message').required().withMessage('Message is required');
+  }
+
+  private onTurnstileSuccess(event: CustomEvent): void {
+    this.contactViewModel.turnstileToken = event.detail.token;
+  }
+
+  private async sendContactInfo(): Promise<void> {
+    const result = await this.validationController.validate();
+    if (!result.valid) {
+      return;
+    }
+
+    if (!this.contactViewModel.turnstileToken) {
+      console.error('Turnstile token is missing. Please complete the CAPTCHA.');
+      return;
+    }
+
+    await this.homeService.sendContactInfo(this.contactViewModel);
+    await this.router.load('home');
+  }
+}
+```
+
+In this example, `contactViewModel.turnstileToken` is part of the payload sent to the backend, so the token reaches the server together with the rest of the form data.
+
+For example, a service method can submit the full view model as JSON:
+
+```ts
+public sendContactInfo(contact: IContactViewModel) {
+  return this.http.post('/api/contact', contact);
+}
+```
+
+### Using the Callback Bindable
+
+You can also use the `callback` bindable directly. Note that you need to `.bind(this)` the method in your constructor to preserve context.
+
+```html
+<turnstile callback.bind="onTurnstileSuccess"></turnstile>
+```
+
+```ts
+export class ContactPage {
+  constructor() {
+    this.onTurnstileSuccess = this.onTurnstileSuccess.bind(this);
+  }
+
+  private onTurnstileSuccess(token: string): void {
+    this.turnstileToken = token;
+  }
+}
+```
+
+### Bindable Properties
+
+All bindable properties are optional if the corresponding value is provided via plugin configuration.
+
+| Property    | Type                       | Description                                                                 |
+|-------------|----------------------------|-----------------------------------------------------------------------------|
+| `sitekey`   | `string`                   | Overrides the configured site key for this instance                         |
+| `callback`  | `(token: string) => void`  | Called with the verification token on successful challenge completion       |
+| `theme`     | `string`                   | Overrides the configured theme (`'light'`, `'dark'`, or `'auto'`)          |
+| `scriptUrl` | `string`                   | Overrides the configured script URL                                        |
+
+### Events
+
+| Event                | Detail                | Description                                         |
+|----------------------|-----------------------|-----------------------------------------------------|
+| `turnstile-verified` | `{ token: string }`   | Dispatched when the user passes the Turnstile challenge |
+
+### Override Configuration Per-Instance
+
+```html
+<turnstile sitekey="DIFFERENT_KEY" theme="dark" turnstile-verified.trigger="onVerify($event)"></turnstile>
+```
+
+### Multiple Widgets
+
+You can use multiple `<turnstile>` elements on a single page. The script is loaded only once regardless of how many widgets are rendered.
+
+```html
+<turnstile turnstile-verified.trigger="onVerifyForm1($event)"></turnstile>
+<turnstile turnstile-verified.trigger="onVerifyForm2($event)" theme="dark"></turnstile>
+```
+
+## Server-Side Verification
+
+The token must be verified on your server by calling the Cloudflare siteverify endpoint:
+
+```
+POST https://challenges.cloudflare.com/turnstile/v0/siteverify
+```
+
+Cloudflare expects `application/x-www-form-urlencoded` form fields, not a JSON request body. The request fields are:
+
+```text
+secret=YOUR_SECRET_KEY
+response=TOKEN_FROM_EVENT
+remoteip=OPTIONAL_USER_IP
+```
+
+### .NET Example
+
+Add the secret key to configuration:
+
+```json
+{
+  "Turnstile": {
+    "SecretKey": "YOUR_SECRET_KEY"
+  }
+}
+```
+
+Register the verification service in DI:
+
+```csharp
+builder.Services.AddHttpClient<TurnstileVerificationService>();
+```
+
+```csharp
+using System.Net.Http.Json;
+using Microsoft.Extensions.Configuration;
+
+public sealed class TurnstileVerificationService(HttpClient httpClient, IConfiguration configuration)
+{
+  private readonly HttpClient httpClient = httpClient;
+  private readonly IConfiguration configuration = configuration;
+
+  public async Task<bool> VerifyTokenAsync(string token, string? remoteIp = null, CancellationToken cancellationToken = default)
+  {
+    var secretKey = configuration["Turnstile:SecretKey"];
+
+    if (string.IsNullOrWhiteSpace(secretKey))
+      throw new InvalidOperationException("Turnstile:SecretKey is not configured.");
+
+    if (string.IsNullOrWhiteSpace(token))
+      return false;
+
+    var form = new Dictionary<string, string>
+    {
+      ["secret"] = secretKey,
+      ["response"] = token
+    };
+
+    if (!string.IsNullOrWhiteSpace(remoteIp))
+      form["remoteip"] = remoteIp;
+
+    using var content = new FormUrlEncodedContent(form);
+    using var response = await httpClient
+      .PostAsync("https://challenges.cloudflare.com/turnstile/v0/siteverify", content, cancellationToken)
+      .ConfigureAwait(false);
+
+    if (!response.IsSuccessStatusCode)
+      return false;
+
+    var payload = await response.Content
+      .ReadFromJsonAsync<TurnstileVerifyResponse>(cancellationToken: cancellationToken)
+      .ConfigureAwait(false);
+
+    return payload?.Success == true;
+  }
+
+  private sealed class TurnstileVerifyResponse
+  {
+    public bool Success { get; set; }
+  }
+}
+```
+
+  Receive the token from the client and verify it before accepting the submission:
+
+  ```csharp
+  public sealed class ContactRequest
+  {
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string Subject { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public string TurnstileToken { get; set; } = string.Empty;
+  }
+
+  app.MapPost("/api/contact", async (
+    ContactRequest request,
+    HttpContext httpContext,
+    TurnstileVerificationService turnstileVerificationService,
+    CancellationToken cancellationToken) =>
+  {
+    var remoteIp = httpContext.Connection.RemoteIpAddress?.ToString();
+
+    var isValid = await turnstileVerificationService.VerifyTokenAsync(
+      request.TurnstileToken,
+      remoteIp,
+      cancellationToken);
+
+    if (!isValid)
+      return Results.BadRequest(new { message = "Turnstile verification failed." });
+
+    return Results.Ok();
+  });
+  ```
+
+  The client-side token should be treated as untrusted until the server verifies it successfully.
+
+  ## Testing
+
+  Cloudflare provides test keys so you can develop without creating production widgets immediately.
+
+  Common test sitekeys:
+
+  - `1x00000000000000000000AA`: always passes
+  - `2x00000000000000000000AB`: always fails
+  - `3x00000000000000000000FF`: forces an interactive challenge
+
+  Matching test secret keys:
+
+  - `1x0000000000000000000000000000000AA`: always passes validation
+  - `2x0000000000000000000000000000000AA`: always fails validation
+  - `3x0000000000000000000000000000000AA`: returns `timeout-or-duplicate`
+
+  Dummy sitekeys work on local development hosts such as `localhost`, `127.0.0.1`, and `0.0.0.0`.
+
+See the [Cloudflare Turnstile docs](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/) for full details.

--- a/packages/aurelia2-turnstile/jest.config.cjs
+++ b/packages/aurelia2-turnstile/jest.config.cjs
@@ -1,0 +1,8 @@
+﻿const baseConfig = require('../../jest.config.cjs');
+
+module.exports = {
+    ...baseConfig,
+    setupFiles: [
+        "../../test/jest.setup.ts"
+    ],
+};

--- a/packages/aurelia2-turnstile/package.json
+++ b/packages/aurelia2-turnstile/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "aurelia2-turnstile",
+  "version": "1.0.0",
+  "description": "Cloudflare Turnstile integration for Aurelia 2",
+  "main": "./dist/index.js",
+  "types": "./dist/types/index.d.ts",
+  "repository": "https://github.com/Vheissu/aurelia2-plugins",
+  "author": "Dwayne Charrington <dwaynecharrington@gmail.com",
+  "license": "MIT",
+  "scripts": {
+    "clean": "rimraf ./dist",
+    "prebuild": "npm run clean",
+    "build:ts": "tsc",
+    "build:other": "cpx \"./src/**/*.{html,css}\" ./dist",
+    "build": "npm run build:ts && npm run build:other",
+    "watch:ts": "tsc --watch --preserveWatchOutput",
+    "watch:other": "cpx \"./src/**/*.{html,css}\" ./dist --watch",
+    "test:debug": "cross-env DEBUG=true npm run test",
+    "test:watch": "cross-env DEV=true npm run test",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "aurelia": "^2.0.0-rc.1"
+  },
+  "peerDependencies": {
+    "aurelia": ">=2.0.0-rc.1"
+  }
+}

--- a/packages/aurelia2-turnstile/src/configure.ts
+++ b/packages/aurelia2-turnstile/src/configure.ts
@@ -1,0 +1,42 @@
+﻿import { DI } from '@aurelia/kernel';
+
+export interface TurnstileConfigOptions {
+    sitekey?: string;
+    theme?: 'light' | 'dark' | 'auto';
+    scriptUrl?: string;
+}
+
+export interface ITurnstileConfiguration extends Configure {}
+export const ITurnstileConfiguration = DI.createInterface<ITurnstileConfiguration>(
+    'ITurnstileConfiguration',
+    x => x.singleton(Configure)
+);
+
+export class Configure {
+    protected _config: TurnstileConfigOptions;
+
+    constructor() {
+        this._config = {
+            sitekey: '',
+            theme: 'auto',
+            scriptUrl: 'https://challenges.cloudflare.com/turnstile/v0/api.js',
+        };
+    }
+
+    getOptions(): TurnstileConfigOptions {
+        return this._config;
+    }
+
+    options(obj: TurnstileConfigOptions = {}) {
+        Object.assign(this._config, obj);
+    }
+
+    get(key: keyof TurnstileConfigOptions) {
+        return this._config[key];
+    }
+
+    set(key: keyof TurnstileConfigOptions, val: any) {
+        this._config[key] = val;
+        return this._config[key];
+    }
+}

--- a/packages/aurelia2-turnstile/src/index.ts
+++ b/packages/aurelia2-turnstile/src/index.ts
@@ -1,0 +1,41 @@
+﻿import { IContainer, IRegistry } from '@aurelia/kernel';
+import { ITurnstileConfiguration, TurnstileConfigOptions } from './configure';
+import { TurnstileCustomElement } from './turnstile-custom-element';
+
+export { TurnstileCustomElement } from './turnstile-custom-element';
+export { Configure, ITurnstileConfiguration } from './configure';
+export type { TurnstileConfigOptions } from './configure';
+
+const DefaultComponents: IRegistry[] = [
+    TurnstileCustomElement as unknown as IRegistry,
+];
+
+function createTurnstileConfiguration(options: Partial<TurnstileConfigOptions>) {
+    return {
+        register(container: IContainer) {
+            const configClass = container.get(ITurnstileConfiguration);
+            configClass.options(options);
+            return container.register(...DefaultComponents);
+        },
+        configure(options: TurnstileConfigOptions) {
+            return createTurnstileConfiguration(options);
+        },
+        customize(callback?: (config: ITurnstileConfiguration) => void) {
+            return {
+                register(container: IContainer) {
+                    const configClass = container.get(ITurnstileConfiguration);
+                    configClass.options(options);
+                    if (callback) {
+                        callback(configClass);
+                    }
+                    return container.register(...DefaultComponents);
+                },
+                configure(options: TurnstileConfigOptions) {
+                    return createTurnstileConfiguration(options);
+                },
+            };
+        },
+    };
+}
+
+export const TurnstileConfiguration = createTurnstileConfiguration({});

--- a/packages/aurelia2-turnstile/src/turnstile-custom-element.ts
+++ b/packages/aurelia2-turnstile/src/turnstile-custom-element.ts
@@ -1,0 +1,107 @@
+﻿import { bindable, customElement, ICustomElementViewModel, INode } from '@aurelia/runtime-html';
+import { inject } from '@aurelia/kernel';
+import { ITurnstileConfiguration } from './configure';
+
+@customElement({
+    name: 'turnstile',
+    template: '<template><div ref="container"></div></template>',
+})
+@inject(INode, ITurnstileConfiguration)
+export class TurnstileCustomElement implements ICustomElementViewModel {
+    @bindable public sitekey: string = '';
+    @bindable public callback: ((token: string) => void) | undefined;
+    @bindable public theme: string = '';
+    @bindable public scriptUrl: string = '';
+
+    private container!: HTMLElement;
+    private widgetId: string | undefined;
+    private scriptLoaded = false;
+
+    constructor(
+        private readonly element: HTMLElement,
+        private readonly config: ITurnstileConfiguration
+    ) {}
+
+    attached() {
+        const resolvedSitekey = this.sitekey || this.config.get('sitekey') || '';
+        if (!resolvedSitekey) {
+            console.error('Turnstile sitekey is required. Provide it via bindable or configuration.');
+            return;
+        }
+
+        if ((window as any).turnstile) {
+            this.renderTurnstile();
+            return;
+        }
+
+        const resolvedUrl = this.scriptUrl || this.config.get('scriptUrl') ||
+            'https://challenges.cloudflare.com/turnstile/v0/api.js';
+
+        this.loadScript(resolvedUrl);
+    }
+
+    detached() {
+        if (this.widgetId !== undefined && (window as any).turnstile) {
+            (window as any).turnstile.remove(this.widgetId);
+            this.widgetId = undefined;
+        }
+    }
+
+    private loadScript(url: string) {
+        const existingScript = document.querySelector(`script[src="${url}"]`);
+        if (existingScript || this.scriptLoaded) {
+            this.onScriptReady();
+            return;
+        }
+
+        const script = document.createElement('script');
+        script.src = url;
+        script.async = true;
+        script.defer = true;
+        script.onload = () => {
+            this.scriptLoaded = true;
+            this.onScriptReady();
+        };
+        script.onerror = () => {
+            console.error('Failed to load Turnstile script.');
+        };
+        document.head.appendChild(script);
+    }
+
+    private onScriptReady() {
+        if ((window as any).turnstile) {
+            this.renderTurnstile();
+        } else {
+            // Script element exists but API not yet available; poll briefly
+            let attempts = 0;
+            const interval = setInterval(() => {
+                attempts++;
+                if ((window as any).turnstile) {
+                    clearInterval(interval);
+                    this.renderTurnstile();
+                } else if (attempts > 50) {
+                    clearInterval(interval);
+                    console.error('Turnstile API did not become available.');
+                }
+            }, 100);
+        }
+    }
+
+    private renderTurnstile() {
+        const resolvedSitekey = this.sitekey || this.config.get('sitekey') || '';
+        const resolvedTheme = this.theme || this.config.get('theme') || 'auto';
+
+        this.widgetId = (window as any).turnstile.render(this.container, {
+            sitekey: resolvedSitekey,
+            callback: (token: string) => {
+                this.element.dispatchEvent(new CustomEvent('turnstile-verified', {
+                    bubbles: true,
+                    composed: true,
+                    detail: { token },
+                }));
+                this.callback?.(token);
+            },
+            theme: resolvedTheme,
+        });
+    }
+}

--- a/packages/aurelia2-turnstile/test/turnstile.spec.ts
+++ b/packages/aurelia2-turnstile/test/turnstile.spec.ts
@@ -1,0 +1,306 @@
+﻿import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+import { Configure } from '../src/configure';
+import { TurnstileCustomElement } from '../src/turnstile-custom-element';
+import { TurnstileConfiguration } from '../src/index';
+
+type TurnstileRenderOptions = {
+    callback: (token: string) => void;
+};
+
+type TurnstileVerifiedEvent = CustomEvent<{ token: string }>;
+
+describe('aurelia2-turnstile', () => {
+    let consoleSpy: ReturnType<typeof jest.spyOn>;
+    let originalTurnstile: any;
+
+    beforeEach(() => {
+        consoleSpy = jest.spyOn(console, 'error').mockImplementation((..._args: unknown[]) => undefined);
+        originalTurnstile = (window as any).turnstile;
+        delete (window as any).turnstile;
+    });
+
+    afterEach(() => {
+        consoleSpy.mockRestore();
+        if (originalTurnstile !== undefined) {
+            (window as any).turnstile = originalTurnstile;
+        } else {
+            delete (window as any).turnstile;
+        }
+
+        document.querySelectorAll('script[src*="turnstile"]').forEach(el => el.remove());
+    });
+
+    describe('Configure', () => {
+        test('has sensible defaults', () => {
+            const config = new Configure();
+            const opts = config.getOptions();
+
+            expect(opts.sitekey).toBe('');
+            expect(opts.theme).toBe('auto');
+            expect(opts.scriptUrl).toBe('https://challenges.cloudflare.com/turnstile/v0/api.js');
+        });
+
+        test('options() merges values', () => {
+            const config = new Configure();
+            config.options({ sitekey: 'my-key', theme: 'dark' });
+
+            expect(config.get('sitekey')).toBe('my-key');
+            expect(config.get('theme')).toBe('dark');
+            expect(config.get('scriptUrl')).toBe('https://challenges.cloudflare.com/turnstile/v0/api.js');
+        });
+
+        test('set() updates a single value', () => {
+            const config = new Configure();
+            config.set('sitekey', 'updated-key');
+
+            expect(config.get('sitekey')).toBe('updated-key');
+        });
+    });
+
+    describe('TurnstileCustomElement', () => {
+        function createComponent(configOverrides: Partial<ReturnType<Configure['getOptions']>> = {}) {
+            const config = new Configure();
+            config.options(configOverrides);
+
+            const element = document.createElement('turnstile');
+            const sut = new TurnstileCustomElement(element, config);
+
+            // Simulate the ref binding that Aurelia would do
+            (sut as any).container = document.createElement('div');
+
+            return { sut, config, element };
+        }
+
+        test('logs error when no sitekey is provided', () => {
+            const { sut } = createComponent();
+
+            sut.attached();
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Turnstile sitekey is required. Provide it via bindable or configuration.'
+            );
+        });
+
+        test('uses sitekey from configuration when not set via bindable', () => {
+            const renderMock = jest.fn().mockReturnValue('widget-1');
+            (window as any).turnstile = { render: renderMock };
+
+            const { sut } = createComponent({ sitekey: 'config-key' });
+
+            sut.attached();
+
+            expect(renderMock).toHaveBeenCalledWith(
+                expect.any(HTMLElement),
+                expect.objectContaining({ sitekey: 'config-key' })
+            );
+        });
+
+        test('bindable sitekey takes precedence over configuration', () => {
+            const renderMock = jest.fn().mockReturnValue('widget-1');
+            (window as any).turnstile = { render: renderMock };
+
+            const { sut } = createComponent({ sitekey: 'config-key' });
+            sut.sitekey = 'bindable-key';
+
+            sut.attached();
+
+            expect(renderMock).toHaveBeenCalledWith(
+                expect.any(HTMLElement),
+                expect.objectContaining({ sitekey: 'bindable-key' })
+            );
+        });
+
+        test('renders turnstile widget when API is available', () => {
+            const renderMock = jest.fn().mockReturnValue('widget-1');
+            (window as any).turnstile = { render: renderMock };
+
+            const callback = jest.fn();
+            const { sut } = createComponent({ sitekey: 'test-key' });
+            sut.callback = callback;
+            sut.theme = 'dark';
+
+            sut.attached();
+
+            expect(renderMock).toHaveBeenCalledWith(
+                expect.any(HTMLElement),
+                expect.objectContaining({
+                    sitekey: 'test-key',
+                    theme: 'dark',
+                    callback: expect.any(Function),
+                })
+            );
+        });
+
+        test('dispatches turnstile-verified event with token', () => {
+            let capturedCallback: (token: string) => void;
+            const renderMock = jest.fn<(element: HTMLElement, opts: TurnstileRenderOptions) => string>().mockImplementation((_el, opts) => {
+                capturedCallback = opts.callback;
+                return 'widget-1';
+            });
+            (window as any).turnstile = { render: renderMock };
+
+            const { sut, element } = createComponent({ sitekey: 'test-key' });
+            const eventSpy = jest.fn<(event: TurnstileVerifiedEvent) => void>();
+            element.addEventListener('turnstile-verified', ((event: Event) => {
+                eventSpy(event as TurnstileVerifiedEvent);
+            }) as EventListener);
+
+            sut.attached();
+            capturedCallback!('test-token-123');
+
+            expect(eventSpy).toHaveBeenCalledTimes(1);
+            expect(eventSpy.mock.calls[0][0].detail).toEqual({ token: 'test-token-123' });
+        });
+
+        test('calls callback bindable and dispatches event together', () => {
+            let capturedCallback: (token: string) => void;
+            const renderMock = jest.fn<(element: HTMLElement, opts: TurnstileRenderOptions) => string>().mockImplementation((_el, opts) => {
+                capturedCallback = opts.callback;
+                return 'widget-1';
+            });
+            (window as any).turnstile = { render: renderMock };
+
+            const callbackSpy = jest.fn();
+            const { sut, element } = createComponent({ sitekey: 'test-key' });
+            sut.callback = callbackSpy;
+            const eventSpy = jest.fn<(event: TurnstileVerifiedEvent) => void>();
+            element.addEventListener('turnstile-verified', ((event: Event) => {
+                eventSpy(event as TurnstileVerifiedEvent);
+            }) as EventListener);
+
+            sut.attached();
+            capturedCallback!('my-token');
+
+            expect(callbackSpy).toHaveBeenCalledWith('my-token');
+            expect(eventSpy).toHaveBeenCalledTimes(1);
+            expect(eventSpy.mock.calls[0][0].detail).toEqual({ token: 'my-token' });
+            expect(eventSpy.mock.calls[0][0].composed).toBe(true);
+        });
+
+        test('uses theme from configuration when not set via bindable', () => {
+            const renderMock = jest.fn().mockReturnValue('widget-1');
+            (window as any).turnstile = { render: renderMock };
+
+            const { sut } = createComponent({ sitekey: 'test-key', theme: 'auto' });
+
+            sut.attached();
+
+            expect(renderMock).toHaveBeenCalledWith(
+                expect.any(HTMLElement),
+                expect.objectContaining({ theme: 'auto' })
+            );
+        });
+
+        test('does not append duplicate script tags', () => {
+            const existingScript = document.createElement('script');
+            existingScript.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js';
+            document.head.appendChild(existingScript);
+
+            const renderMock = jest.fn().mockReturnValue('widget-1');
+            (window as any).turnstile = { render: renderMock };
+
+            const { sut } = createComponent({ sitekey: 'test-key' });
+
+            sut.attached();
+
+            const scripts = document.querySelectorAll(
+                'script[src="https://challenges.cloudflare.com/turnstile/v0/api.js"]'
+            );
+            expect(scripts.length).toBe(1);
+        });
+
+        test('appends script tag when turnstile API is not loaded', () => {
+            const { sut } = createComponent({ sitekey: 'test-key' });
+
+            sut.attached();
+
+            const scripts = document.querySelectorAll(
+                'script[src="https://challenges.cloudflare.com/turnstile/v0/api.js"]'
+            );
+            expect(scripts.length).toBe(1);
+        });
+
+        test('uses custom scriptUrl from bindable', () => {
+            const { sut } = createComponent({ sitekey: 'test-key' });
+            sut.scriptUrl = 'https://custom-cdn.example.com/turnstile.js';
+
+            sut.attached();
+
+            const scripts = document.querySelectorAll(
+                'script[src="https://custom-cdn.example.com/turnstile.js"]'
+            );
+            expect(scripts.length).toBe(1);
+        });
+
+        test('detached removes the widget', () => {
+            const removeMock = jest.fn();
+            const renderMock = jest.fn().mockReturnValue('widget-1');
+            (window as any).turnstile = { render: renderMock, remove: removeMock };
+
+            const { sut } = createComponent({ sitekey: 'test-key' });
+
+            sut.attached();
+            sut.detached();
+
+            expect(removeMock).toHaveBeenCalledWith('widget-1');
+        });
+
+        test('detached does nothing when widget was not rendered', () => {
+            const { sut } = createComponent();
+
+            // Should not throw
+            sut.detached();
+        });
+    });
+
+    describe('TurnstileConfiguration', () => {
+        test('register() returns a container', () => {
+            const registrations: any[] = [];
+            const mockConfig = new Configure();
+            const mockContainer = {
+                get: jest.fn().mockReturnValue(mockConfig),
+                register: jest.fn().mockReturnThis(),
+            };
+
+            TurnstileConfiguration.register(mockContainer as any);
+
+            expect(mockContainer.get).toHaveBeenCalled();
+            expect(mockContainer.register).toHaveBeenCalled();
+        });
+
+        test('configure() returns a new configuration with options', () => {
+            const configured = TurnstileConfiguration.configure({
+                sitekey: 'my-key',
+                theme: 'dark',
+            });
+
+            const mockConfig = new Configure();
+            const mockContainer = {
+                get: jest.fn().mockReturnValue(mockConfig),
+                register: jest.fn().mockReturnThis(),
+            };
+
+            configured.register(mockContainer as any);
+
+            expect(mockConfig.get('sitekey')).toBe('my-key');
+            expect(mockConfig.get('theme')).toBe('dark');
+        });
+
+        test('customize() allows callback-style configuration', () => {
+            const customized = TurnstileConfiguration.customize((config) => {
+                config.set('sitekey', 'callback-key');
+            });
+
+            const mockConfig = new Configure();
+            const mockContainer = {
+                get: jest.fn().mockReturnValue(mockConfig),
+                register: jest.fn().mockReturnThis(),
+            };
+
+            customized.register(mockContainer as any);
+
+            expect(mockConfig.get('sitekey')).toBe('callback-key');
+        });
+    });
+});

--- a/packages/aurelia2-turnstile/tsconfig.json
+++ b/packages/aurelia2-turnstile/tsconfig.json
@@ -1,0 +1,11 @@
+﻿{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "declarationDir": "./dist/types",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a new `aurelia2-turnstile` package for integrating Cloudflare Turnstile into Aurelia 2 applications.

The plugin provides a configurable `<turnstile>` custom element, loads the Turnstile script on demand, supports both callback-based and event-based consumption, and includes documentation and tests for common integration scenarios.

## Features

- new `aurelia2-turnstile` package
- `<turnstile>` custom element for rendering the Cloudflare Turnstile widget
- plugin configuration via `TurnstileConfiguration.configure(...)` and `customize(...)`
- per-instance overrides for `sitekey`, `theme`, and `scriptUrl`
- `turnstile-verified` custom event with `{ token }` detail
- optional callback bindable for direct token handling
- script deduplication so multiple widgets do not load the API multiple times
- widget cleanup on detach

## Documentation

Adds a README with:
- installation and registration examples
- `configure()` vs `customize()` usage
- event-based and callback-based examples
- CSP guidance
- server-side verification guidance
- .NET verification example
- Cloudflare test keys

## Validation

- `npm run test --workspace=packages/aurelia2-turnstile`
- `npm run build --workspace=packages/aurelia2-turnstile`
- `npm pack`